### PR TITLE
Fix UUID string formatting crash in CBUUID.toUuid()

### DIFF
--- a/lib/src/iosMain/kotlin/client/Uuid.kt
+++ b/lib/src/iosMain/kotlin/client/Uuid.kt
@@ -37,6 +37,6 @@ import platform.CoreBluetooth.CBUUID
 
 internal fun Uuid.toCBUUID(): CBUUID = CBUUID.UUIDWithString(toString())
 internal fun CBUUID.toUuid(): Uuid = when (UUIDString.length) {
-    4 -> uuidFrom("0000$UUIDString-0000-1000-8000- 00805F9B34FB")
+    4 -> uuidFrom("0000$UUIDString-0000-1000-8000-00805F9B34FB")
     else -> uuidFrom(UUIDString)
 }


### PR DESCRIPTION
## Problem
The `CBUUID.toUuid()` function was crashing when converting 4-character UUID strings due to an extra space in the UUID template string.

## Root Cause
There was an errant space in the UUID template: `"0000$UUIDString-0000-1000-8000- 00805F9B34FB"` (note the space before the last segment), which resulted in an invalid UUID string length crash in iOS.

## Solution
Removed the extra space from the UUID template string:
```kotlin
// Before
uuidFrom("0000$UUIDString-0000-1000-8000- 00805F9B34FB")

// After  
uuidFrom("0000$UUIDString-0000-1000-8000-00805F9B34FB")